### PR TITLE
Def vs run sim

### DIFF
--- a/data_prep.py
+++ b/data_prep.py
@@ -4,6 +4,8 @@ import os
 
 
 
+def embodied_emissions_kbob(asdf):
+    pass
 
 
 def electric_appliances_sia(energy_reference_area, type=1, value="standard"):
@@ -28,7 +30,7 @@ def electric_appliances_sia(energy_reference_area, type=1, value="standard"):
     else:
         print("No demand schedule for electrical appliances has been defined for this case.")
 
-    return demand_profile #Wh
+    return demand_profile * energy_reference_area #Wh
 
 
 def build_yearly_emission_factors(export_assumption="c"):

--- a/data_prep.py
+++ b/data_prep.py
@@ -4,8 +4,46 @@ import os
 
 
 
-def embodied_emissions_kbob(asdf):
-    pass
+def embodied_emissions_heat_generation_kbob_per_kW(system_type):
+    """
+    This function takes a heat generation system type and returns the respective embodied emissions per kW of installed
+    power.
+    --> this function is very basic and needs to be improved.
+    :param system_type: string of gshp, ashp, electric heater
+    :return: float, embodied kgCO2 equivalent per kW of installed power
+    """
+
+    ## Define embodied emissions: # In a later stage this could be included in the RC model "supply_system.py file"
+    if system_type == "gshp":
+        coeq = 272.5 #kg/kW [KBOB 2016]
+    elif system_type == "ashp":
+        coeq = 363.75 #kg/kW [KBOB 2016]
+
+    elif system_type == "electric heater":
+        coeq = 7.2/5.0  #kg/kW [ecoinvent auxiliary heating unit production, electric, 5kW]
+
+    else:
+        print("Embodied emissions for this system type are not defined")
+        pass
+
+    return coeq
+
+def embodied_emissions_borehole_per_m():
+
+    coeq_borehole = 28.1 #kg/m[KBOB 2016]
+    return coeq_borehole
+
+def embodied_emissions_heat_emission_system_per_m2(em_system_type):
+
+    if em_system_type == "underfloor heating":
+        coeq_underfloor_heating = 5.06 #kg/m2 [KBOB]
+
+    return coeq_underfloor_heating
+
+def embodied_emissions_pv_per_kW():
+    coeq_pv = 2080 # kg/kWp [KBOB 2016]
+    return coeq_pv
+
 
 
 def electric_appliances_sia(energy_reference_area, type=1, value="standard"):

--- a/data_prep.py
+++ b/data_prep.py
@@ -46,6 +46,18 @@ def embodied_emissions_pv_per_kW():
 
 
 
+def persons_from_area_sia(energy_reference_area, type=1):
+
+    if type ==1:
+        personenflache = 50.  # m2/p
+
+    elif type == 3:
+        personenflache = 14.
+
+    occupants = energy_reference_area / personenflache
+    return occupants
+
+
 def electric_appliances_sia(energy_reference_area, type=1, value="standard"):
     """
     This function calculates the use of electric appliances according to SIA 2024

--- a/definition.py
+++ b/definition.py
@@ -16,58 +16,17 @@ from radiation import PhotovoltaicSurface
 def run_simulation(external_envelope_area, window_area, room_width, room_depth, room_height,
                    thermal_capacitance_per_floor_area, u_walls, u_windows, ach_vent, ach_infl, ventilation_efficiency,
                    max_heating_energy_per_floor_area, max_cooling_energy_per_floor_area, pv_area, pv_efficiency,
-                   pv_tilt, pv_azimuth, lifetime, strom_mix, weatherfile_path, grid_decarbonization_factors):
+                   pv_tilt, pv_azimuth, lifetime, strom_mix, weatherfile_path, grid_decarbonization_factors,
+                   t_set_heating, t_set_cooling):
 
-
-
-    # dirname = os.path.dirname(__file__)
-    # wall_data_path = os.path.join(dirname, 'data/walls.xlsx')
-
-    # Zurich = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_simulator\auxiliary\Zurich-Kloten_2013.epw")
-    # Recife = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\BRA_Recife.828990_IWEC.epw")
-    # SaoPaolo = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\BRA_Sao.Paulo-Congonhas.837800_SWERA.epw")
-    # Vancouver = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\CAN_BC_Vancouver.718920_CWEC.epw")
-    # PuntaArenas = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\CHL_Punta.Arenas.859340_IWEC.epw")
-    # Stuttgart = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\DEU_Stuttgart.107380_IWEC.epw")
-    # Copenhagen = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\DNK_Copenhagen.061800_IWEC.epw")
-    # Algier = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\DZA_Algiers.603900_IWEC.epw")
-    # Barcelona = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\ESP_Barcelona.081810_IWEC.epw")
-    # London = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\GBR_London.Gatwick.037760_IWEC.epw")
-    # Milano = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\ITA_Milano-Linate.160800_IGDG.epw")
-    # Rome =Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\ITA_Roma-Ciampino.162390_IGDG.epw")
-    # Kiruna = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\SWE_Kiruna.020440_IWEC.epw")
-    # Ostersund = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\SWE_Ostersund.Froson.022260_IWEC.epw")
-    # LongBeach_LA = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\USA_CA_Long.Beach-Daugherty.Field.722970_TMY3.epw")
-    # DesMoines = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\USA_IA_Des.Moines.Intl.AP.725460_TMY3.epw")
-    # Chicago = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw")
-
-    # wall_name = "Betonwand, Wärmedämmung mit Lattenrost, Verkleidung"
-    # wall_name = "Holzblockwand, Aussenwärmedämmung, Verkleidung"
-    # wall_name = "Sichtbetonwand, Aussenwärmedämmung verputzt"
-    # wall_name = "Sichtbacksteinmauerwerk, Aussenwärmedämmung verputzt"
-
-
-
-
-
-    # LocList = [Zurich, Recife, SaoPaolo, Vancouver, PuntaArenas, Stuttgart, Copenhagen, Algier, Barcelona, London, Milano,
-    #            Rome, Kiruna, Ostersund, LongBeach_LA, DesMoines, Chicago]
-
-    # Loc = Zurich
 
     Loc = Location(epwfile_path=weatherfile_path)
 
-
-
+    ## So far the lighting load is still hard coded because it is not looked at.
     lighting_load=11.7  # [W/m2] (source?)
     lighting_control = 300.0  # lux threshold at which the lights turn on.
     lighting_utilisation_factor=0.45
     lighting_maintenance_factor=0.9
-
-
-    t_set_heating = 20.0
-    t_set_cooling = 26.0
-
 
     use_type = 3  # only goes into electrical appliances according to SIA (1=residential, 3= office)
 
@@ -145,11 +104,6 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
                     cooling_emission_system=emission_system.FloorHeating,)
 
 
-    ### emission factors according to empa_Alice Chevrier Semester Project in g/Wh
-
-    # aproximated values from the graph
-
-
 
     SouthWindow = Window(azimuth_tilt=0., alititude_tilt = 90.0, glass_solar_transmittance=0.5,
                          glass_light_transmittance=0.5, area =window_area)
@@ -179,9 +133,6 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
 
     coeq_el_heater = 7.2/5.0  #kg/kW [ecoinvent auxiliary heating unit production, electric, 5kW]
 
-    #standard on GWP100, 0.18m insulation
-    # coeq_wall = dp.extract_wall_data(wall_data_path, name=wall_name, area=external_envelope_area-window_area)
-
 
     #electricity demand from appliances
 
@@ -189,7 +140,7 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
 
 
     #Starting temperature of the builidng:
-    t_m_prev=20.0
+    t_m_prev=20.0 # This is only for the very first step in therefore is hard coded.
 
 
     # hourly_emission_factors = dp.build_yearly_emission_factors(strom_mix)
@@ -263,10 +214,7 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
             emission_cold_demand.append(Office.cooling_demand)
             indoor_temperature.append(Office.t_air)
 
-        plt.plot(indoor_temperature)
-        plt.axhline(20)
-        plt.axhline(26)
-        plt.show()
+
         electricity_demand = electricity_demand + electric_appliances
         heating_demands_list.append(heating_demand)  # This is the electricity needed for heating with the respective system
         heat_emission_list.append(emission_heat_demand)  # This is the actual heat emitted
@@ -338,32 +286,6 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
 
     normalized_total_emissions = normalized_annual_embodied_emissions+normalized_annual_operational_emissions
 
-    annual_heating_demand = sum(heating_demand)/(room_depth*room_width)
-    annual_cooling_demand = sum(cooling_demand)/(room_depth*room_width)
-    #
-    # #
-    # fig, ax1 = plt.subplots()
-    # ax1.bar([0,1,2], normalized_annual_embodied_emissions, color="lightblue", label="embodied systems")
-    # ax1.bar([0,1,2], normalized_annual_operational_emissions, bottom=normalized_annual_embodied_emissions,
-    #              color="blue", label="grid allocated")
-    # ax1.bar([0,1,2], [pv_embodied*embodied_pv_ratio[0]/lifetime/(room_depth*room_width),
-    #                        pv_embodied*embodied_pv_ratio[1]/lifetime/(room_depth*room_width),
-    #                        pv_embodied*embodied_pv_ratio[2]/lifetime/(room_depth*room_width)], color="y",
-    #         label="PV allocated")
-    #
-    # ax1.set_title("U_opaque=" + str(u_walls) + " and U windows=" + str(u_windows) + "\nAirChangeInf=" +str(ach_infl) + " AirChangeVent=" + str(ach_vent) + " PV=" + str(kwp_pv) +"kW" )
-    # ax1.set_ylabel("kgCO2eq/(a*m2)")
-    # plt.xticks([0,1,2], ("Pure electric", "ASHP", "GSHP"))
-    # ax2 = ax1.twinx()
-    # ax2.axhline(annual_heating_demand/1000, color="red", label="heating demand")
-    # ax2.axhline(annual_cooling_demand/1000, color= "blue", label="cooling demand")
-    # ax2.set_ylabel("kWh/(a*m2)")
-    # ax2.set_ylim(0)
-    # plt.figlegend(loc="center right", bbox_to_anchor=(0.88,0.67))
-    # plt.show()
-
-
-
 
 
     return normalized_total_emissions, normalized_annual_operational_emissions, normalized_annual_embodied_emissions,\
@@ -373,16 +295,6 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
 
 
 
-    #Visualize hourly values
-    # plt.plot(range(8760), operational_emissions[0], label="direct_power", c="red", ls='--', lw="0.7", marker=".", ms=0.7 )
-    # plt.plot(range(8760), operational_emissions[1], label="ASHP", c="blue", ls='--', lw="0.7", marker=".", ms=0.7)
-    # plt.plot(range(8760), operational_emissions[2], label="GSHP", c="green", ls='--', lw="0.7", marker=".", ms=0.7)
-    #
-    # plt.plot(range(8760), net_electricity_demands_list[0], label="direct_power", c="lightcoral", ls='--', lw="0.7", marker=".", ms=0.7)
-    # plt.plot(range(8760), net_electricity_demands_list[1], label="ASHP", c="lightblue", ls='--', lw="0.7",marker=".", ms=0.7)
-    # plt.plot(range(8760), net_electricity_demands_list[2], label="GSHP", c="lightgreen", ls='--',lw="0.7", marker=".", ms=0.7)
-    # plt.legend()
-    # plt.show()
 
 def comfort_assessment(indoor_temperature_time_series, comfort_range=[19.0, 25.0], discomfort_type="integrated"):
     """

--- a/definition.py
+++ b/definition.py
@@ -1,10 +1,8 @@
 import sys
 sys.path.insert(1, r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_simulator")
-import os
 from building_physics import Building
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 import data_prep as dp
 import supply_system
 import emission_system
@@ -13,11 +11,11 @@ from radiation import Window
 from radiation import PhotovoltaicSurface
 
 
-def run_simulation(external_envelope_area, window_area, room_width, room_depth, room_height,
+def run_rc_simulation(external_envelope_area, window_area, room_width, room_depth, room_height,
                    thermal_capacitance_per_floor_area, u_walls, u_windows, ach_vent, ach_infl, ventilation_efficiency,
                    max_heating_energy_per_floor_area, max_cooling_energy_per_floor_area, pv_area, pv_efficiency,
                    pv_tilt, pv_azimuth, lifetime, strom_mix, weatherfile_path, grid_decarbonization_factors,
-                   t_set_heating, t_set_cooling):
+                   t_set_heating, t_set_cooling, annual_dhw_p_person, dhw_supply_temperature, use_type):
 
 
     Loc = Location(epwfile_path=weatherfile_path)
@@ -28,13 +26,16 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
     lighting_utilisation_factor=0.45
     lighting_maintenance_factor=0.9
 
-    annual_dhw_p_person = 36400  # Wh/(p*a) SIA2024 für MFH wären es 582000 Wh/(p*a) aus hard code rausnehmen
-    dhw_supply_temperature = 60  # degC
 
-    use_type = 3  # only goes into electrical appliances according to SIA (1=residential, 3= office)
+    ## Define constants
+
+    gain_per_person = 100 # W per sqm (why is that per sqm when it says per person?)
+    appliance_gains= 14 #W per sqm
+    max_occupancy=50  # number of occupants (could be simplified by using area per person values)
+    floor_area = room_width * room_depth
 
 
-    Office_1X = Building(window_area=window_area,
+    Office = Building(window_area=window_area,
                     external_envelope_area=external_envelope_area,
                     room_depth=room_depth,
                     room_width=room_width,
@@ -59,57 +60,6 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
                     cooling_emission_system=emission_system.AirConditioning,
                     dhw_supply_temperature=dhw_supply_temperature,)
 
-    Office_2X = Building(window_area=window_area,
-                    external_envelope_area=external_envelope_area,
-                    room_depth=room_depth,
-                    room_width=room_width,
-                    room_height=room_height,
-                    lighting_load=lighting_load,
-                    lighting_control = lighting_control,
-                    lighting_utilisation_factor=lighting_utilisation_factor,
-                    lighting_maintenance_factor=lighting_maintenance_factor,
-                    u_walls = u_walls,
-                    u_windows = u_windows,
-                    ach_vent=ach_vent,
-                    ach_infl=ach_infl,
-                    ventilation_efficiency=ventilation_efficiency,
-                    thermal_capacitance_per_floor_area = thermal_capacitance_per_floor_area,
-                    t_set_heating = t_set_heating,
-                    t_set_cooling = t_set_cooling,
-                    max_cooling_energy_per_floor_area=max_cooling_energy_per_floor_area[1],
-                    max_heating_energy_per_floor_area=max_heating_energy_per_floor_area[1],
-                    heating_supply_system=supply_system.HeatPumpAir,
-                    cooling_supply_system=supply_system.HeatPumpAir,
-                    heating_emission_system=emission_system.FloorHeating,
-                    cooling_emission_system=emission_system.FloorHeating,
-                    dhw_supply_temperature=dhw_supply_temperature,)
-
-    Office_32 = Building(window_area=window_area,
-                    external_envelope_area=external_envelope_area,
-                    room_depth=room_depth,
-                    room_width=room_width,
-                    room_height=room_height,
-                    lighting_load=lighting_load,
-                    lighting_control = lighting_control,
-                    lighting_utilisation_factor=lighting_utilisation_factor,
-                    lighting_maintenance_factor=lighting_maintenance_factor,
-                    u_walls = u_walls,
-                    u_windows = u_windows,
-                    ach_vent=ach_vent,
-                    ach_infl=ach_infl,
-                    ventilation_efficiency=ventilation_efficiency,
-                    thermal_capacitance_per_floor_area = thermal_capacitance_per_floor_area,
-                    t_set_heating = t_set_heating,
-                    t_set_cooling = t_set_cooling,
-                    max_cooling_energy_per_floor_area=max_cooling_energy_per_floor_area[2],
-                    max_heating_energy_per_floor_area=max_heating_energy_per_floor_area[2],
-                    heating_supply_system=supply_system.HeatPumpWater,
-                    cooling_supply_system=supply_system.HeatPumpWater,
-                    heating_emission_system=emission_system.FloorHeating,
-                    cooling_emission_system=emission_system.FloorHeating,
-                    dhw_supply_temperature=dhw_supply_temperature, )
-
-
 
     SouthWindow = Window(azimuth_tilt=0., alititude_tilt = 90.0, glass_solar_transmittance=0.5,
                          glass_light_transmittance=0.5, area =window_area)
@@ -124,11 +74,7 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
     occupancyProfile=pd.read_csv(r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_simulator\auxiliary\occupancy_office.csv")
 
 
-    ## Define constants
 
-    gain_per_person = 100 # W per sqm
-    appliance_gains= 14 #W per sqm
-    max_occupancy=2.5  # number of occupants (could be simplified by using area per person values)
 
     ## Define embodied emissions: # In a later stage this could be included in the RC model "supply_system.py file"
     coeq_gshp = dp.embodied_emissions_heat_generation_kbob_per_kW("gshp")  # kgCO2/kW ## zusätzlich automatisieren
@@ -152,152 +98,153 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
     # hourly_emission_factors = dp.build_monthly_emission_factors(strom_mix)
     hourly_emission_factors = dp.build_yearly_emission_factors(strom_mix)
     hourly_emission_factors = hourly_emission_factors*grid_decarbonization_factors.mean()
-    office_list = [Office_1X, Office_2X, Office_32]
-
-
-    electricity_demands_list = []
-    pv_yields_list = []
-    heating_demands_list = []
-    cooling_demands_list = []
-    indoor_temperature_list = []
-    heat_emission_list = []
-    cold_emission_list = []
-
-
-    for Office in office_list:
-        electricity_demand = np.empty(8760)
-        solar_yield = np.empty(8760)
-        heating_demand = []
-        cooling_demand = []
-        solar_gains = []
-        indoor_temperature = []
-        emission_heat_demand = []
-        emission_cold_demand = []
-
-        for hour in range(8760):
-
-            #Occupancy for the time step
-            occupancy = occupancyProfile.loc[hour,'People'] * max_occupancy
-            #Gains from occupancy and appliances
-            internal_gains = occupancy*gain_per_person + appliance_gains*Office.floor_area
-
-            # Domestic hot water schedule
-            dhw_demand = annual_dhw_p_person/ occupancyProfile['People'].sum() * occupancy  # Wh
-
-            #Extract the outdoor temperature in Zurich for that hour
-            t_out = Loc.weather_data['drybulb_C'][hour]
-
-            Altitude, Azimuth = Loc.calc_sun_position(latitude_deg=47.480, longitude_deg=8.536, year=2015, hoy=hour)
-
-            SouthWindow.calc_solar_gains(sun_altitude = Altitude, sun_azimuth = Azimuth,
-                                         normal_direct_radiation= Loc.weather_data['dirnorrad_Whm2'][hour],
-                                         horizontal_diffuse_radiation = Loc.weather_data['difhorrad_Whm2'][hour])
-
-            SouthWindow.calc_illuminance(sun_altitude = Altitude, sun_azimuth = Azimuth,
-                                         normal_direct_illuminance = Loc.weather_data['dirnorillum_lux'][hour],
-                                         horizontal_diffuse_illuminance = Loc.weather_data['difhorillum_lux'][hour])
-
-            RoofPV.calc_solar_yield(sun_altitude = Altitude, sun_azimuth=Azimuth,
-                                   normal_direct_radiation=Loc.weather_data['dirnorrad_Whm2'][hour],
-                                   horizontal_diffuse_radiation=Loc.weather_data['difhorrad_Whm2'][hour])
-
-
-            Office.solve_building_energy(internal_gains=internal_gains, solar_gains=SouthWindow.solar_gains,t_out=t_out,
-                                         t_m_prev=t_m_prev, dhw_demand=dhw_demand)
-
-            Office.solve_building_lighting(illuminance=SouthWindow.transmitted_illuminance, occupancy=occupancy)
-
-            #Set the previous temperature for the next time step
-
-            t_m_prev=Office.t_m_next
 
 
 
-            heating_demand.append(Office.heating_sys_electricity)
-            cooling_demand.append(Office.cooling_sys_electricity)
-            solar_gains.append(SouthWindow.solar_gains)
-            electricity_demand[hour] = Office.heating_sys_electricity + Office.cooling_sys_electricity + Office.dhw_sys_electricity
-            solar_yield[hour]=RoofPV.solar_yield
-            emission_heat_demand.append(Office.heating_demand)
-            emission_cold_demand.append(Office.cooling_demand)
-            indoor_temperature.append(Office.t_air)
+
+    electricity_demand = np.empty(8760)
+    pv_yield = np.empty(8760)
+    total_heat_demand = np.empty(8760)
+    heating_electricity_demand = np.empty(8760)
+    heating_demand = np.empty(8760)
+    cooling_electricity_demand = np.empty(8760)
+    cooling_demand = np.empty(8760)
+    solar_gains = np.empty(8760)
+    indoor_temperature = np.empty(8760)
 
 
-        electricity_demand = electricity_demand + electric_appliances
-        heating_demands_list.append(heating_demand)  # This is the electricity needed for heating with the respective system
-        heat_emission_list.append(emission_heat_demand)  # This is the actual heat emitted
-        cooling_demands_list.append(cooling_demand)  # This is the electricity needed for cooling with the respective system
-        cold_emission_list.append(emission_cold_demand) # This is the actual col "emitted"
-        electricity_demands_list.append(electricity_demand) # in Wh
-        pv_yields_list.append(solar_yield) #in Wh
-        indoor_temperature_list.append(indoor_temperature)
-    floor_area = room_width * room_depth
-    max_required_heating_per_floor_area = [max(heat_emission_list[0])/floor_area,
-                                           max(heat_emission_list[1])/floor_area,
-                                           max(heat_emission_list[2])/floor_area]  # W/m2
-    max_required_cooling_per_floor_area = [min(cold_emission_list[0])/floor_area,
-                                           min(cold_emission_list[1])/floor_area,
-                                           min(cold_emission_list[2])/floor_area]  # W/m2
+    for hour in range(8760):
+
+        #Occupancy for the time step
+        occupancy = occupancyProfile.loc[hour,'People'] * max_occupancy
+        #Gains from occupancy and appliances
+        internal_gains = occupancy*gain_per_person + appliance_gains*Office.floor_area
+
+        # Domestic hot water schedule
+        dhw_demand = annual_dhw_p_person/ occupancyProfile['People'].sum() * occupancy  # Wh
+
+        #Extract the outdoor temperature in Zurich for that hour
+        t_out = Loc.weather_data['drybulb_C'][hour]
+
+        Altitude, Azimuth = Loc.calc_sun_position(latitude_deg=47.480, longitude_deg=8.536, year=2015, hoy=hour)
+
+        SouthWindow.calc_solar_gains(sun_altitude = Altitude, sun_azimuth = Azimuth,
+                                     normal_direct_radiation= Loc.weather_data['dirnorrad_Whm2'][hour],
+                                     horizontal_diffuse_radiation = Loc.weather_data['difhorrad_Whm2'][hour])
+
+        SouthWindow.calc_illuminance(sun_altitude = Altitude, sun_azimuth = Azimuth,
+                                     normal_direct_illuminance = Loc.weather_data['dirnorillum_lux'][hour],
+                                     horizontal_diffuse_illuminance = Loc.weather_data['difhorillum_lux'][hour])
+
+        RoofPV.calc_solar_yield(sun_altitude = Altitude, sun_azimuth=Azimuth,
+                               normal_direct_radiation=Loc.weather_data['dirnorrad_Whm2'][hour],
+                               horizontal_diffuse_radiation=Loc.weather_data['difhorrad_Whm2'][hour])
 
 
-    net_electricity_demands_list = np.subtract(electricity_demands_list, pv_yields_list)
+        Office.solve_building_energy(internal_gains=internal_gains, solar_gains=SouthWindow.solar_gains,t_out=t_out,
+                                     t_m_prev=t_m_prev, dhw_demand=dhw_demand)
 
-    net_self_consumption = np.empty((len(office_list), 8760))
-    for i in range(len(office_list)):
-        for hour in range(8760):
-            net_self_consumption[i][hour] = min(pv_yields_list[i][hour], electricity_demands_list[i][hour])
+        Office.solve_building_lighting(illuminance=SouthWindow.transmitted_illuminance, occupancy=occupancy)
+
+        #Set the previous temperature for the next time step
+
+        t_m_prev=Office.t_m_next
+
+
+
+        heating_electricity_demand[hour] =Office.heating_sys_electricity  # unit? heating electricity demand
+        cooling_electricity_demand[hour] = Office.cooling_sys_electricity  # unit?
+        solar_gains[hour] = SouthWindow.solar_gains
+        electricity_demand[hour] = Office.heating_sys_electricity + Office.dhw_sys_electricity + Office.cooling_sys_electricity  # in Wh
+        pv_yield[hour]=RoofPV.solar_yield  # in Wh
+        heating_demand[hour] = Office.heating_demand  # this is the actual heat emitted, unit?
+        cooling_demand[hour] = Office.cooling_demand
+        indoor_temperature[hour] = Office.t_air
+
+        total_heat_demand[hour] = Office.heating_demand + Office.dhw_demand
+
+
+
+    electricity_demand = electricity_demand + electric_appliances
+
+
+
+
+    max_required_heating_per_floor_area = max(heating_demand)/floor_area  # W/m2
+    max_required_cooling_per_floor_area = min(cooling_demand)/floor_area  # W/m2
+
+
+    net_electricity_demand = np.subtract(electricity_demand, pv_yield)
+
+    net_self_consumption = np.empty(8760)
+    for hour in range(8760):
+        net_self_consumption[hour] = min(pv_yield[hour], electricity_demand[hour])
 
 
     # this is the ratio of electricity used to electricity produced and thus the emissions that are allocated to the building.
-    embodied_pv_ratio = net_self_consumption.sum(axis=1)/np.array(pv_yields_list).sum(axis=1)
+    # This is highly questionable, meaning, it is discussed a lot
+    embodied_pv_ratio = net_self_consumption.sum()/pv_yield.sum()
 
 
 
-    net_operational_emissions = np.multiply(net_electricity_demands_list/1000.,hourly_emission_factors)
+    net_operational_emissions = np.multiply(net_electricity_demand / 1000., hourly_emission_factors)
     operational_emissions = np.copy(net_operational_emissions)
-    operational_emissions[operational_emissions<0] = 0.00
+    operational_emissions[operational_emissions < 0] = 0.00
 
 
-    ## embodied emissions:
+    ## heat calculations:
+    annual_normalized_heat_demand = heating_demand.sum()/1000 / floor_area
 
-    #PV
-    kwp_pv = RoofPV.area * RoofPV.efficiency # = kWp
-    pv_embodied = kwp_pv*coeq_pv
+    print("Annual_normalized_heat_demand:")
+    print(annual_normalized_heat_demand)
 
 
-    # direct electrical
-    embodied_direct = coeq_el_heater * np.percentile(heating_demands_list[0],97.5)/1000. + pv_embodied * embodied_pv_ratio[0] #_embodied emissions of the electrical heating system
-
-    # ASHP
-    ashp_power = np.percentile(heating_demands_list[1],97.5)/1000. #kW
-    ashp_embodied = coeq_ashp*ashp_power # kgCO2eq
-    underfloor_heating_embodied = coeq_underfloor_heating * Office_2X.floor_area # kgCO2eq
-    embodied_ashp = ashp_embodied + underfloor_heating_embodied + pv_embodied*embodied_pv_ratio[1]
-
-    # GSHP
-    borehole_depth = 20 #m/kW - entspricht einer spezifischen Entzugsleistung von 50W/m
-    gshp_power = np.percentile(heating_demands_list[2],97.5)/1000 #kW
-    gshp_embodied = coeq_gshp * gshp_power # kgCO2eq
+    ## embodied emissions:    DO NOT YET USE THIS PART OF THE SIMULATION!!!!!
+    #
+    # #PV
+    # kwp_pv = RoofPV.area * RoofPV.efficiency # = kWp
+    # pv_embodied = kwp_pv*coeq_pv
+    #
+    #
+    # # direct electrical
+    # embodied_direct = coeq_el_heater * np.percentile(heating_electricity_demand, 97.5)/1000. \
+    #                   + pv_embodied * embodied_pv_ratio #_embodied emissions of the electrical heating system
+    #
+    # # ASHP
+    # ashp_power = np.percentile(heating_el_demands_list[1],97.5)/1000. #kW
+    # ashp_embodied = coeq_ashp*ashp_power # kgCO2eq
     # underfloor_heating_embodied = coeq_underfloor_heating * Office_2X.floor_area # kgCO2eq
-    borehole_embodied = coeq_borehole * borehole_depth * gshp_power
-    embodied_gshp = gshp_embodied + underfloor_heating_embodied + borehole_embodied + pv_embodied * embodied_pv_ratio[2]
-    embodied_emissions = np.array([embodied_direct, embodied_ashp, embodied_gshp])
+    # embodied_ashp = ashp_embodied + underfloor_heating_embodied + pv_embodied*embodied_pv_ratio[1]
+    #
+    # # GSHP
+    # borehole_depth = 20 #m/kW - entspricht einer spezifischen Entzugsleistung von 50W/m
+    # gshp_power = np.percentile(heating_el_demands_list[2],97.5)/1000 #kW
+    # gshp_embodied = coeq_gshp * gshp_power # kgCO2eq
+    # # underfloor_heating_embodied = coeq_underfloor_heating * Office_2X.floor_area # kgCO2eq
+    # borehole_embodied = coeq_borehole * borehole_depth * gshp_power
+    # embodied_gshp = gshp_embodied + underfloor_heating_embodied + borehole_embodied + pv_embodied * embodied_pv_ratio[2]
+    # embodied_emissions = np.array([embodied_direct, embodied_ashp, embodied_gshp])
+    #
+    #
+    # # Annual for 25years lifetime
+    # annual_embodied_emissions = embodied_emissions/lifetime
+    # normalized_annual_embodied_emissions = annual_embodied_emissions/(room_width*room_depth)
 
-
-    # Annual for 25years lifetime
-    annual_embodied_emissions = embodied_emissions/lifetime
-    normalized_annual_embodied_emissions = annual_embodied_emissions/(room_width*room_depth)
     #### Total emissions
-    annual_operational_emissions = operational_emissions.sum(axis=1)
+    annual_operational_emissions = operational_emissions.sum()
     normalized_annual_operational_emissions = annual_operational_emissions/(room_width*room_depth)
 
-    normalized_total_emissions = normalized_annual_embodied_emissions+normalized_annual_operational_emissions
+    # normalized_total_emissions = normalized_annual_embodied_emissions+normalized_annual_operational_emissions
+
+    normalized_total_emissions = 0  # placeholder
+    normalized_annual_embodied_emissions = 0  # placeholder
+
 
 
 
     return normalized_total_emissions, normalized_annual_operational_emissions, normalized_annual_embodied_emissions,\
            u_windows, u_walls, thermal_capacitance_per_floor_area, max_required_heating_per_floor_area,\
-           max_required_cooling_per_floor_area, indoor_temperature_list
+           max_required_cooling_per_floor_area, indoor_temperature
 
 
 

--- a/definition.py
+++ b/definition.py
@@ -111,7 +111,7 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
     ## Define PV to this building
 
     RoofPV = PhotovoltaicSurface(azimuth_tilt=pv_azimuth, alititude_tilt = pv_tilt, stc_efficiency=pv_efficiency,
-                         performance_ratio=0.8, area = pv_area)
+                         performance_ratio=0.8, area = pv_area)  # Performance ratio is still hard coded.
 
 
     ## Define occupancy
@@ -122,16 +122,15 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
 
     gain_per_person = 100 # W per sqm
     appliance_gains= 14 #W per sqm
-    max_occupancy=4.0
+    max_occupancy=4.0  # What are the dimensions of this?
 
     ## Define embodied emissions: # In a later stage this could be included in the RC model "supply_system.py file"
-    coeq_gshp = 272.5 #kg/kW [KBOB 2016]
-    coeq_borehole = 28.1 #kg/m[KBOB 2016]
-    coeq_ashp = 363.75 #kg/kW [KBOB 2016]
-    coeq_underfloor_heating = 5.06 #kg/m2 [KBOB]
-    coeq_pv = 2080 # kg/kWp [KBOB 2016]
-
-    coeq_el_heater = 7.2/5.0  #kg/kW [ecoinvent auxiliary heating unit production, electric, 5kW]
+    coeq_gshp = dp.embodied_emissions_heat_generation_kbob_per_kW("gshp")  # kgCO2/kW ## zusätzlich automatisieren
+    coeq_borehole = dp.embodied_emissions_borehole_per_m() #kg/m
+    coeq_ashp = dp.embodied_emissions_heat_generation_kbob_per_kW("ashp")  # kgCO2/kW ## zusätzlich automatisieren
+    coeq_underfloor_heating = dp.embodied_emissions_heat_emission_system_per_m2("underfloor heating") #kg/m2
+    coeq_pv = dp.embodied_emissions_pv_per_kW()  # kg/kWp
+    coeq_el_heater = dp.embodied_emissions_heat_generation_kbob_per_kW("electric heater")  #kg/kW
 
 
     #electricity demand from appliances
@@ -219,7 +218,7 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
         heating_demands_list.append(heating_demand)  # This is the electricity needed for heating with the respective system
         heat_emission_list.append(emission_heat_demand)  # This is the actual heat emitted
         cooling_demands_list.append(cooling_demand)  # This is the electricity needed for cooling with the respective system
-        cold_emission_list.append(emission_cold_demand) # This is the actual heat emitted
+        cold_emission_list.append(emission_cold_demand) # This is the actual col "emitted"
         electricity_demands_list.append(electricity_demand) # in Wh
         pv_yields_list.append(solar_yield) #in Wh
         indoor_temperature_list.append(indoor_temperature)
@@ -258,8 +257,7 @@ def run_simulation(external_envelope_area, window_area, room_width, room_depth, 
 
 
     # direct electrical
-    el_underfloor_heating_embodied = coeq_underfloor_heating * Office_2X.floor_area # kgCO2eq [wird als zusatz genommen weil mit heater alleine ja noch nicht geheizt]
-    embodied_direct = coeq_el_heater * np.percentile(heating_demands_list[0],97.5)/1000. +el_underfloor_heating_embodied + pv_embodied * embodied_pv_ratio[0] #_embodied emissions of the electrical heating system
+    embodied_direct = coeq_el_heater * np.percentile(heating_demands_list[0],97.5)/1000. + pv_embodied * embodied_pv_ratio[0] #_embodied emissions of the electrical heating system
 
     # ASHP
     ashp_power = np.percentile(heating_demands_list[1],97.5)/1000. #kW

--- a/main.py
+++ b/main.py
@@ -1,0 +1,64 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import definition as de
+
+### Pfade zu weiteren Daten
+weatherfile_path = r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_simulator\auxiliary\Zurich-Kloten_2013.epw"
+occupancy_path = r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_simulator\auxiliary\occupancy_office.csv"
+
+
+
+### Erforderliche Nutzereingaben:
+gebaeudekategorie_sia = 1.1
+regelung = "andere"  # oder "Referenzraum" oder "andere"
+hohe_uber_meer = 435.0 # Eingabe
+energiebezugsflache = 2275.0  # m2
+anlagennutzungsgrad_wrg = 0.0 ## SIA 380-1 Tab 23
+warmespeicherfahigkeit_pro_EBF = 0.08 ## gemäss SN EN ISO 13786 oder Tab25 [kWh/m2K]
+korrekturfaktor_luftungs_eff_f_v = 1.0  # zwischen 0.8 und 1.2 gemäss SIA380-1 Tab 24
+infiltration_volume_flow = 0.15  # Gemäss SIA 380-1 2016 3.5.5 soll 0.15m3/(hm2) verwendet werden. Korrigenda anschauen
+cooling_setpoint = 27  # deg C
+
+## Gebäudehülle
+u_windows = 1.30
+u_walls = 0.25
+u_roof = 0.19
+u_floor = 0.23
+b_floor = 0.4
+
+
+## Systeme
+heizsystem = "HP"
+dhw_heizsystem = "HP"
+
+
+
+
+### Bauteile:
+## Windows: [[Orientation],[Areas],[U-value],[g-value]]
+windows = np.array([["N", "E", "S", "W"],
+                    [131.5, 131.5, 131.5, 131.5],
+                    [u_windows, u_windows, u_windows, u_windows],
+                    [0.6, 0.6, 0.6, 0.6]],
+                   dtype=object)  # dtype=object is necessary because there are different data types
+
+## walls: [[Areas], [U-values]]
+walls = np.array([[412.5, 412.5, 412.5, 412.5],
+                  [u_walls, u_walls, u_walls, u_walls]])
+
+
+## roof: [[Areas], [U-values]]
+roof = np.array([[506.0], [u_roof]])
+
+## floor to ground (for now) [[Areas],[U-values],[b-values]]
+floor = np.array([[506.0],[u_floor],[b_floor]])
+
+
+Gebaeude_1 = de.Sim_Building(gebaeudekategorie_sia, regelung, windows, walls, roof, floor, energiebezugsflache,
+                         anlagennutzungsgrad_wrg, infiltration_volume_flow, warmespeicherfahigkeit_pro_EBF,
+                         korrekturfaktor_luftungs_eff_f_v, hohe_uber_meer)
+
+Gebaeude_1.run_rc_simulation(weatherfile_path=weatherfile_path,
+                             occupancy_path=occupancy_path, cooling_setpoint=cooling_setpoint)
+
+print(Gebaeude_1.heating_demand.sum()/1000.0/energiebezugsflache)

--- a/robustness.py
+++ b/robustness.py
@@ -29,12 +29,15 @@ ach_infl= 1.5 # Air changes per hour through infiltration [Air Changes Per Hour]
 ventilation_efficiency=0.4
 max_cooling_energy_per_floor_area= [-np.inf, -np.inf, -np.inf]  # W/m2
 max_heating_energy_per_floor_area= [np.inf, np.inf, np.inf]  # W/m2
+heating_temp = 20.0  # The room will be heated to 20.0 deg C
+cooling_temp = 26.0  # The room will be cooled to 26.0 deg C
 pv_area = 2.5 #m2
 pv_efficiency = 0.18
 pv_tilt = 45
 pv_azimuth = 0
 lifetime = 30.0 ## Here this is only the lifetime of the building systems, not the building.
 strom_mix = "d"
+
 
 year_of_construction = 2020
 
@@ -130,7 +133,8 @@ result_values = definition.run_simulation(external_envelope_area, window_area, r
                               thermal_capacitance_per_floor_area, u_walls, u_windows, ach_vent, ach_infl,
                               ventilation_efficiency, max_heating_energy_per_floor_area,
                               max_cooling_energy_per_floor_area, pv_area, pv_efficiency, pv_tilt, pv_azimuth,
-                              lifetime, strom_mix, weatherfile_path, decarb_grid_factors)
+                              lifetime, strom_mix, weatherfile_path, decarb_grid_factors, heating_temp,
+                                    cooling_temp)
 
 required_heating_power_per_floor_area = result_values[6]
 required_cooling_power_per_floor_area = result_values[7]
@@ -167,7 +171,8 @@ for i in range(number_of_simulations):
                                         thermal_capacitance_per_floor_area, u_walls, u_windows, ach_vent, ach_infl,
                                         ventilation_efficiency, max_heating_energy_per_floor_area,
                                         max_cooling_energy_per_floor_area, pv_area, pv_efficiency, pv_tilt, pv_azimuth,
-                                        lifetime, strom_mix, weatherfile_path, decarb_grid_factors)
+                                        lifetime, strom_mix, weatherfile_path, decarb_grid_factors, heating_temp,
+                                    cooling_temp)
 
     print(indoor_temperature_list)
     plt.plot(indoor_temperature_list)

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 
 
 
-
+occupancy_path = r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_simulator\auxiliary\occupancy_office.csv"
 
 # wall_name = "Betonwand, Wärmedämmung mit Lattenrost, Verkleidung"
 wall_name = "Holzblockwand, Aussenwärmedämmung, Verkleidung"

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -41,22 +41,31 @@ weatherfile_path = r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_sim
 
 
 
-
-window_area = 10.0
+## Bauteile / Construction parts
+window_area = 526
 ## Add window g-value here!
-external_envelope_area=15.0  # m2 (south oriented)
-room_depth=7.0  # m
-room_width=5.0  # m
-room_height=3.0  # m
-u_windows = 1.0  # W/m2K
-ach_vent= 2.0  # Air changes per hour through ventilation [Air Changes Per Hour]
-ach_infl= 1.5 # Air changes per hour through infiltration [Air Changes Per Hour]
-ventilation_efficiency=0.4
+external_envelope_area=1650  # m2 (south oriented)
+room_depth=22.5  # m
+room_width=22.5  # m
+room_height=4.5*3  # m
+u_windows = 0.6 # W/m2K
+ach_vent= 0.7*0.4  # Air changes per hour through ventilation [Air Changes Per Hour]
+ach_infl= 0.0 # Air changes per hour through infiltration [Air Changes Per Hour] must be very low for good buildings.
+ventilation_efficiency=0.
 max_cooling_energy_per_floor_area=[-np.inf, -np.inf, -np.inf]
 max_heating_energy_per_floor_area=[np.inf, np.inf, np.inf]
-pv_area = 2.5 #m2
+
+## Domestic hot water
+annual_dhw_p_person = 582000  # Wh/(p*a) SIA2024  für Office 36400 für MFH wären es 582000 Wh/(p*a) aus hard code rausnehmen
+dhw_supply_temperature = 60  # degC
+
+## SIA use type
+use_type = 1  # only goes into electrical appliances according to SIA (1=residential, 3= office)
+
+
+pv_area = 360 #m2
 pv_efficiency = 0.18
-pv_tilt = 45
+pv_tilt = 5
 pv_azimuth = 0
 lifetime = 30.0 ## Here this is only the lifetime of the building systems, not the building.
 strom_mix = "d"
@@ -64,8 +73,11 @@ strom_mix = "d"
 grid_decarbonization_until = 2050  # Choose from 2050, 2060 and 2080
 grid_decarbonization_type = 'linear'  # Choose from 'linear', exponential, quadratic, constant
 
-u_walls = dp.extract_wall_data(wall_data_path, name=wall_name, type="U-value")
-print("U value: " + str(u_walls))
+
+###
+# u_walls = dp.extract_wall_data(wall_data_path, name=wall_name, type="U-value")
+# print("U value: " + str(u_walls))
+u_walls = 0.08
 
 
 
@@ -91,55 +103,39 @@ cooling_temp = 26.0
 
 
 
-# data_list = [0.01,0.5, 1., 2, 3.5, 8, 10, 50, 100, 500, 1000] #pv area
-# data_list = [15,20,25,30,35,40,45] #lifetime
-# data_list = [0.1, 2, 6, 8, 12, 15]  # window area
-# data_list = [0.15, 0.18, 0.20, 0.22, .24, 0.26] # PV efficiency
-# data_list = [0,10,20,30,40,50,60,70,80,90] # PV tilt
-# data_list = [-90, -70, -50, -30, -10, 0, 10, 30, 50, 70, 90]
-# data_list = [0.1, 0.2, 0.4, 0.5, 0.6, 0.8, 0.9]
-data_list = [0.1, 0.2, 0.5, 0.8]
-
-emission_array = np.empty((len(data_list),3))
 
 
-for i in range(len(data_list)) :
-    # pv_area = data_list[i]
-    # lifetime = data_list[i]
-    # window_area = data_list[i]
-    # pv_efficiency = data_list[i]
-    # pv_tilt = data_list[i]
-    # pv_azimuth = data_list[i]
-    ventilation_efficiency = data_list[i]
+normalized_total_emissions, normalized_annual_operational_emissions, normalized_annual_embodied_emissions, \
+u_windows, u_walls, thermal_capacitance_per_floor_area, max_required_heating_per_floor_area, \
+max_required_cooling_per_floor_area, indoor_temperature_list\
+    = definition.run_rc_simulation(external_envelope_area=external_envelope_area,
+                                window_area=window_area,
+                                room_width=room_width,
+                                room_depth =room_depth,
+                                room_height=room_height,
+                                thermal_capacitance_per_floor_area=thermal_capacitance_per_floor_area,
+                                u_walls=u_walls,
+                                u_windows=u_windows,
+                                ach_vent=ach_vent,
+                                ach_infl=ach_infl,
+                                ventilation_efficiency=ventilation_efficiency,
+                                max_heating_energy_per_floor_area=max_heating_energy_per_floor_area,
+                                max_cooling_energy_per_floor_area=max_cooling_energy_per_floor_area,
+                                pv_area=pv_area,
+                                pv_efficiency=pv_efficiency,
+                                pv_tilt=pv_tilt,
+                                pv_azimuth=pv_azimuth,
+                                lifetime=lifetime,
+                                strom_mix=strom_mix,
+                                weatherfile_path=weatherfile_path,
+                                grid_decarbonization_factors=decarb_grid_factors,
+                                t_set_heating=heating_temp,
+                                t_set_cooling=cooling_temp,
+                                annual_dhw_p_person=annual_dhw_p_person,
+                                dhw_supply_temperature=dhw_supply_temperature,
+                                use_type=use_type)
 
-    normalized_total_emissions, normalized_annual_operational_emissions, normalized_annual_embodied_emissions, \
-    u_windows, u_walls, thermal_capacitance_per_floor_area, max_required_heating_per_floor_area, \
-    max_required_cooling_per_floor_area, indoor_temperature_list\
-        = definition.run_simulation(external_envelope_area, window_area, room_width, room_depth, room_height,
-                                    thermal_capacitance_per_floor_area, u_walls, u_windows, ach_vent, ach_infl,
-                                    ventilation_efficiency, max_heating_energy_per_floor_area,
-                                    max_cooling_energy_per_floor_area, pv_area, pv_efficiency, pv_tilt, pv_azimuth,
-                                    lifetime, strom_mix, weatherfile_path, decarb_grid_factors, heating_temp,
-                                    cooling_temp)
 
-    emission_array[i] = normalized_total_emissions
+print(normalized_annual_operational_emissions)
 
-emission_array
-print(emission_array)
 
-xlabel = "PV efficiency"
-
-ylabel = "Annual emissions (kgCO2eq/m2 a)"
-plt.plot(data_list, emission_array)
-plt.title( "emissions vs " + str(xlabel))
-plt.ylabel(ylabel)
-plt.xlabel(xlabel)
-plt.legend(["pure electric", "ASHP", "GSHP"])
-# plt.savefig(r"C:/Users/walkerl/polybox/phd/proof_of_concept/plots/19_10_01/low_area/" + str(xlabel) + ".png")
-plt.show()
-
-data = pd.DataFrame(data = (window_area, external_envelope_area, room_depth, room_width, room_height, u_windows, u_walls,
-                    ach_vent,ach_infl, ventilation_efficiency, max_cooling_energy_per_floor_area,
-                    max_heating_energy_per_floor_area, pv_area, pv_efficiency, pv_tilt, pv_azimuth, lifetime, strom_mix,
-                    thermal_capacitance_per_floor_area))
-print(data)

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -5,13 +5,41 @@ import data_prep as dp
 import os
 import matplotlib.pyplot as plt
 
+
+
+
+
+
 # wall_name = "Betonwand, Wärmedämmung mit Lattenrost, Verkleidung"
 wall_name = "Holzblockwand, Aussenwärmedämmung, Verkleidung"
 # wall_name = "Sichtbetonwand, Aussenwärmedämmung verputzt"
 # wall_name = "Sichtbacksteinmauerwerk, Aussenwärmedämmung verputzt"
 
+
+# Zurich = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_simulator\auxiliary\Zurich-Kloten_2013.epw")
+# Recife = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\BRA_Recife.828990_IWEC.epw")
+# SaoPaolo = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\BRA_Sao.Paulo-Congonhas.837800_SWERA.epw")
+# Vancouver = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\CAN_BC_Vancouver.718920_CWEC.epw")
+# PuntaArenas = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\CHL_Punta.Arenas.859340_IWEC.epw")
+# Stuttgart = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\DEU_Stuttgart.107380_IWEC.epw")
+# Copenhagen = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\DNK_Copenhagen.061800_IWEC.epw")
+# Algier = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\DZA_Algiers.603900_IWEC.epw")
+# Barcelona = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\ESP_Barcelona.081810_IWEC.epw")
+# London = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\GBR_London.Gatwick.037760_IWEC.epw")
+# Milano = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\ITA_Milano-Linate.160800_IGDG.epw")
+# Rome =Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\ITA_Roma-Ciampino.162390_IGDG.epw")
+# Kiruna = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\SWE_Kiruna.020440_IWEC.epw")
+# Ostersund = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\SWE_Ostersund.Froson.022260_IWEC.epw")
+# LongBeach_LA = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\USA_CA_Long.Beach-Daugherty.Field.722970_TMY3.epw")
+# DesMoines = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\USA_IA_Des.Moines.Intl.AP.725460_TMY3.epw")
+# Chicago = Location(epwfile_path=r"C:\Users\walkerl\Documents\code\proof_of_concept\data\USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw")
+
+
 dirname = os.path.dirname(__file__)
 wall_data_path = os.path.join(dirname, 'data/walls.xlsx')
+weatherfile_path = r"C:\Users\walkerl\Documents\code\RC_BuildingSimulator\rc_simulator\auxiliary\Zurich-Kloten_2013.epw"
+
+
 
 
 window_area = 10.0
@@ -24,8 +52,8 @@ u_windows = 1.0  # W/m2K
 ach_vent= 2.0  # Air changes per hour through ventilation [Air Changes Per Hour]
 ach_infl= 1.5 # Air changes per hour through infiltration [Air Changes Per Hour]
 ventilation_efficiency=0.4
-max_cooling_energy_per_floor_area=-np.inf
-max_heating_energy_per_floor_area=np.inf
+max_cooling_energy_per_floor_area=[-np.inf, -np.inf, -np.inf]
+max_heating_energy_per_floor_area=[np.inf, np.inf, np.inf]
 pv_area = 2.5 #m2
 pv_efficiency = 0.18
 pv_tilt = 45
@@ -39,16 +67,16 @@ grid_decarbonization_type = 'linear'  # Choose from 'linear', exponential, quadr
 u_walls = dp.extract_wall_data(wall_data_path, name=wall_name, type="U-value")
 print("U value: " + str(u_walls))
 
-## efficient configuration
-# u_walls = 0.1
-# u_windows = 0.5
-# ventilation_efficiency = 0.75
 
 
-## unefficient configuration
-# u_walls = 0.6
-# u_windows = 2.5
-# ventilation_efficiency = 0.1
+
+grid_decarbonization_year = 2060  # Choose from 2050, 2060 and 2080
+grid_decarbonization_types = 'linear'  # Choose from 'linear', exponential, quadratic, constant
+grid_decarbonization_path = r'C:\Users\walkerl\Documents\code\proof_of_concept\data\future_decarbonization\Decarbonization sceanrios.xlsx'
+from_year = 2020
+to_year = from_year+lifetime
+decarb_grid_factors = dp.extract_decarbonization_factor(grid_decarbonization_path, grid_decarbonization_year,
+                                                            grid_decarbonization_type, from_year, to_year)
 
 
 thermal_capacitance_per_floor_area = dp.extract_wall_data(wall_data_path, name=wall_name,
@@ -58,6 +86,8 @@ thermal_capacitance_per_floor_area = dp.extract_wall_data(wall_data_path, name=w
 
 print("Thermal capacitance per floor area: ", thermal_capacitance_per_floor_area)
 
+heating_temp = 20.0
+cooling_temp = 26.0
 
 
 
@@ -67,8 +97,8 @@ print("Thermal capacitance per floor area: ", thermal_capacitance_per_floor_area
 # data_list = [0.15, 0.18, 0.20, 0.22, .24, 0.26] # PV efficiency
 # data_list = [0,10,20,30,40,50,60,70,80,90] # PV tilt
 # data_list = [-90, -70, -50, -30, -10, 0, 10, 30, 50, 70, 90]
-data_list = [0.1, 0.2, 0.4, 0.5, 0.6, 0.8, 0.9]
-# data_list = [1]
+# data_list = [0.1, 0.2, 0.4, 0.5, 0.6, 0.8, 0.9]
+data_list = [0.1]
 
 emission_array = np.empty((len(data_list),3))
 
@@ -81,20 +111,25 @@ for i in range(len(data_list)) :
     # pv_tilt = data_list[i]
     # pv_azimuth = data_list[i]
     ventilation_efficiency = data_list[i]
-    total_emissions, operational_emissions, embodied_emissions, u_windows, u_walls, thermal_capacitance_per_floor_area\
-        = definition.run_simulation(external_envelope_area, window_area, room_width, room_depth, room_height,
-                                     thermal_capacitance_per_floor_area, u_walls, u_windows, ach_vent, ach_infl, ventilation_efficiency,
-                                     max_heating_energy_per_floor_area, max_cooling_energy_per_floor_area,
-                                     pv_area, pv_efficiency, pv_tilt, pv_azimuth, lifetime, strom_mix)
 
-    emission_array[i] = total_emissions
+    normalized_total_emissions, normalized_annual_operational_emissions, normalized_annual_embodied_emissions, \
+    u_windows, u_walls, thermal_capacitance_per_floor_area, max_required_heating_per_floor_area, \
+    max_required_cooling_per_floor_area, indoor_temperature_list\
+        = definition.run_simulation(external_envelope_area, window_area, room_width, room_depth, room_height,
+                                    thermal_capacitance_per_floor_area, u_walls, u_windows, ach_vent, ach_infl,
+                                    ventilation_efficiency, max_heating_energy_per_floor_area,
+                                    max_cooling_energy_per_floor_area, pv_area, pv_efficiency, pv_tilt, pv_azimuth,
+                                    lifetime, strom_mix, weatherfile_path, decarb_grid_factors, heating_temp,
+                                    cooling_temp)
+
+    emission_array[i] = normalized_total_emissions
 
 emission_array
 print(emission_array)
 
 xlabel = "PV efficiency"
 
-ylabel = "Annual emissions (kgCO2eq/a)"
+ylabel = "Annual emissions (kgCO2eq/m2 a)"
 plt.plot(data_list, emission_array)
 plt.title( "emissions vs " + str(xlabel))
 plt.ylabel(ylabel)

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -98,7 +98,7 @@ cooling_temp = 26.0
 # data_list = [0,10,20,30,40,50,60,70,80,90] # PV tilt
 # data_list = [-90, -70, -50, -30, -10, 0, 10, 30, 50, 70, 90]
 # data_list = [0.1, 0.2, 0.4, 0.5, 0.6, 0.8, 0.9]
-data_list = [0.1]
+data_list = [0.1, 0.2, 0.5, 0.8]
 
 emission_array = np.empty((len(data_list),3))
 


### PR DESCRIPTION
completely new structure. Simulation is now compatible with SIA 380-1 simulation procedure and with original RC simulator. For now, however, all functions concerning operational and embodied emissions have been completely disabled. 
Also indirect inputs of wall data and calculation of hourly emission factors are not included in the definition file. (data_prep.py still contains all the import functions to be readded at a later stage.)
Further, dhw simulations are no longer included but could be easily readded.
--> Some testing should be added.
